### PR TITLE
Allow different versions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,16 @@
 # Usage:
 #
 #     include xctool
-class xctool {
+#
+#   Or:
+#
+#     class {'xctool':
+#       version => '0.1.14'
+#     }
+#
+class xctool($version='latest') {
   package { 'xctool':
-    ensure    => 'latest',
+    ensure    => $version,
     provider  => 'homebrew'
   }
 }


### PR DESCRIPTION
I'd like to be able to specify the version of xctool to use. This patch allows just that, while keeping the original behavior.

Useful when some changes in your build aren't supported by xctool (yet).
